### PR TITLE
Update graceful-fs dependency to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "minimatch": ">=0.2.4",
-    "graceful-fs": "~1.2.2"
+    "graceful-fs": "~2.0.0"
   },
   "devDependencies": {
     "tap": "~0.3.1",


### PR DESCRIPTION
[graceful-fs](https://github.com/isaacs/node-graceful-fs) recently went through a fairly extensive rewrite to address various edge cases. Bumping the version would help consumers dedupe their dependency trees better.
