### PR TITLE
add option to use fs.lstat in replace of fs.stat

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Behaves as follows:
 
 - **depth**: depth at which to stop recursing even if more subdirectories are found
 
+- **lstat**: use fs.lstat instead of fs.stat
+
 ## entry info
 
 Has the following properties:

--- a/readdirp.js
+++ b/readdirp.js
@@ -78,6 +78,7 @@ function readdir(opts, callback1, callback2) {
   opts.fileFilter      =  opts.fileFilter      || function() { return true; };
   opts.directoryFilter =  opts.directoryFilter || function() { return true; };
   opts.depth           =  typeof opts.depth === 'undefined' ? 999999999 : opts.depth;
+  opts.lstat           =  opts.lstat           || false
 
   if (isUndefined(callback2)) {
     fileProcessed = function() { };
@@ -170,9 +171,10 @@ function readdir(opts, callback1, callback2) {
         entries.forEach(function (entry) { 
 
           var fullPath = path.join(realCurrentDir, entry),
-            relPath  = path.join(relDir, entry);
+            relPath  = path.join(relDir, entry),
+            statFunc = !opts.lstat ? fs.stat : fs.lstat;
 
-          fs.stat(fullPath, function (err, stat) {
+          statFunc(fullPath, function (err, stat) {
             if (err) {
               handleError(err);
             } else {


### PR DESCRIPTION
Hi there,

Love the API, but needed the ability to use lstat to filter based on symbolic links. If you like the idea but want a different approach, let me know and I'll be happy to change it. :)

Thanks!
