### PR TITLE
Wait until the next tick to pause the stream

### DIFF
--- a/test/readdirp-stream.js
+++ b/test/readdirp-stream.js
@@ -252,16 +252,19 @@ test('\napi separately', function (t) {
         t.equals(data, processedData, 'emits the buffered data');
         t.ok(resumed, 'emits data only after it was resumed');
       })
-      .pause()
     
-    api.processEntry(processedData);
-    api.handleError(nonfatalError);
-    api.handleFatalError(fatalError);
+    process.nextTick(function() {
+      api.stream.pause();
+
+      api.processEntry(processedData);
+      api.handleError(nonfatalError);
+      api.handleFatalError(fatalError);
   
-    setTimeout(function () {
-      resumed = true;
-      api.stream.resume();
-    }, 1)
+      setTimeout(function () {
+        resumed = true;
+        api.stream.resume();
+      }, 1)
+    })
   })
 
   t.test('\n# when a stream is paused it stops walking the fs', function (t) {


### PR DESCRIPTION
Registering handlers on a stream with `on` causes resume to be called, but only on the next tick.

This leads to a race condition where the pause can happen before that delayed resume, which then resumes the stream earlier than we were expecting.

Reopening as requested in #38 as this still seems to be required for the tests to pass with both nodejs 4.4.5 on Fedora 24 and nodejs 6.2.2 in Fedora Rawhide. Without it we get these two failures:

```
    not ok 21 emits warning only after it was resumed
      ---
        file:   /builddir/build/BUILD/package/test/readdirp-stream.js
        line:   245
        column: 11
        stack:  
          - getCaller (/usr/lib/node_modules/tap/lib/tap-assert.js:418:17)
          - Function.assert (/usr/lib/node_modules/tap/lib/tap-assert.js:21:16)
          - Test._testAssert [as ok] (/usr/lib/node_modules/tap/lib/tap-test.js:87:16)
          - ReaddirpReadable.<anonymous> (/builddir/build/BUILD/package/test/readdirp-stream.js:245:11)
          - emitOne (events.js:96:13)
          - ReaddirpReadable.emit (events.js:188:7)
          - Immediate._onImmediate (/builddir/build/BUILD/package/stream-api.js:75:32)
          - tryOnImmediate (timers.js:543:15)
          - processImmediate [as _immediateCallback] (timers.js:523:5)
      ...
```

and:

```
    not ok 23 emits errors only after it was resumed
      ---
        file:   /builddir/build/BUILD/package/test/readdirp-stream.js
        line:   249
        column: 11
        stack:  
          - getCaller (/usr/lib/node_modules/tap/lib/tap-assert.js:418:17)
          - Function.assert (/usr/lib/node_modules/tap/lib/tap-assert.js:21:16)
          - Test._testAssert [as ok] (/usr/lib/node_modules/tap/lib/tap-test.js:87:16)
          - ReaddirpReadable.<anonymous> (/builddir/build/BUILD/package/test/readdirp-stream.js:249:11)
          - emitOne (events.js:96:13)
          - ReaddirpReadable.emit (events.js:188:7)
          - Immediate._onImmediate (/builddir/build/BUILD/package/stream-api.js:83:32)
          - tryOnImmediate (timers.js:543:15)
          - processImmediate [as _immediateCallback] (timers.js:523:5)
      ...
```
