### PR TITLE
lock event-stream to 3.0.7

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -4,6 +4,6 @@
   "description": "Examples for readdirp.",
   "dependencies": {
     "tap-stream": "~0.1.0",
-    "event-stream": "~3.0.7"
+    "event-stream": "3.0.7"
   }
 }


### PR DESCRIPTION
Since the recent breach in event-stream( https://github.com/dominictarr/event-stream/issues/116) we should lock down the version of event-stream to 3.0.7 to prevent any further attacks