### PR TITLE
Marked callback1 and callback2 optional in jsdoc

### DIFF
--- a/readdirp.js
+++ b/readdirp.js
@@ -9,10 +9,10 @@ var fs        =  require('graceful-fs')
 /**
  * Main function which ends up calling readdirRec and reads all files and directories in given root recursively.
  * @param { Object }   opts     Options to specify root (start directory), filters and recursion depth
- * @param { function } callback1  When callback2 is given calls back for each processed file - function (fileInfo) { ... },
- *                                when callback2 is not given, it behaves like explained in callback2
- * @param { function } callback2  Calls back once all files have been processed with an array of errors and file infos
- *                                function (err, fileInfos) { ... }
+ * @param { function } [callback1]  When callback2 is given calls back for each processed file - function (fileInfo) { ... },
+ *                                  when callback2 is not given, it behaves like explained in callback2
+ * @param { function } [callback2]  Calls back once all files have been processed with an array of errors and file infos
+ *                                  function (err, fileInfos) { ... }
  */
 function readdir(opts, callback1, callback2) {
   var stream


### PR DESCRIPTION
readdirp's optional parameters `callback1` and `callback2` aren't marked optional in their JSdoc, making my IDE complain when using readdirp with a single `opts` argument. I marked the two callbacks optional.