### PR TITLE
Typo of stat(s) in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ for await (const entry of readdirp('.')) {
 // Print out all JS files along with their size within the current folder & subfolders.
 readdirp('.', {fileFilter: '*.js', alwaysStat: true})
   .on('data', (entry) => {
-    const {path, stat: {size}} = entry;
+    const {path, stats: {size}} = entry;
     console.log(`${JSON.stringify({path, size})}`);
   })
   // Optionally call stream.destroy() in `warn()` in order to abort and cause 'close' to be emitted


### PR DESCRIPTION
Hello! Just a new user here. I was just testing out the library and trying to run the example from the readme with the latest npm version, which did not work. After some digging, there's this very minor typo `stat` => `stats`, already mentioned in issue #74

