### PR TITLE
Check if running on Electron (#99)

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ const supportsDirent = 'Dirent' in fs;
  */
 
 const isWindows = process.platform === 'win32';
+// Electron (<4.0.x) utilises custom versions of fs  
+// https://github.com/electron/electron/pull/15323
+const isUnsupportedElectron = process.versions.hasOwnProperty('electron') 
+                                && process.versions.electron[0] <= 4;
 const supportsBigint = typeof BigInt === 'function';
 const BANG = '!';
 const NORMAL_FLOW_ERRORS = new Set(['ENOENT', 'EPERM', 'EACCES', 'ELOOP']);
@@ -167,7 +171,7 @@ class ReaddirpStream extends Readable {
   }
 
   _stat(fullPath) {
-    if (isWindows && supportsBigint) {
+    if (isWindows && supportsBigint && !isUnsupportedElectron) {
       return this._statMethod(fullPath, this._statOpts);
     } else {
       return this._statMethod(fullPath);


### PR DESCRIPTION
This works on my current Atom (1.39 running on Electron 3.1.10)
FWIW,not sure how useful this is, as Atom stable will be Electron 4.x soon https://github.com/atom/atom/pull/19373 but then again, not sure what VS Code's electron upgrade timeline is..

