### PR TITLE
fix: typing

### DIFF
--- a/examples/types.ts
+++ b/examples/types.ts
@@ -1,7 +1,7 @@
-import readdirp from '..';
+import readdirp from 'readdirp';
 
 const read = async (directory: string) => {
-  const stream = readdirp(directory, {type: 'all'});
+  const stream = readdirp(directory, { type: 'all' });
   let i = 0;
   for await (const chunk of stream) {
     // Check memory usage with this line. It should be 10MB or so.

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,36 +2,42 @@
 
 /// <reference types="node" lib="esnext" />
 
-import * as fs from "fs";
-import {Readable} from "stream";
+import * as fs from 'fs';
+import { Readable } from 'stream';
 
-interface EntryInfo {
-  path: string,
-  fullPath: string,
-  basename: string,
-  stats?: fs.Stats,
-  dirent?: fs.Dirent
+declare namespace readdir {
+  interface EntryInfo {
+    path: string;
+    fullPath: string;
+    basename: string;
+    stats?: fs.Stats;
+    dirent?: fs.Dirent;
+  }
+
+  interface ReaddirpOptions {
+    root?: string;
+    fileFilter?: string | string[] | ((entry: EntryInfo) => boolean);
+    directoryFilter?: (entry: EntryInfo) => boolean;
+    type?: 'files' | 'directories' | 'files_directories' | 'all';
+    lstat?: boolean;
+    depth?: number;
+    alwaysStat?: boolean;
+  }
+
+  interface ReaddirpStream extends Readable, AsyncIterable<EntryInfo> {
+    read(): EntryInfo;
+    [Symbol.asyncIterator](): AsyncIterableIterator<EntryInfo>;
+  }
+
+  function promise(
+    root: string,
+    options?: ReaddirpOptions
+  ): Promise<EntryInfo[]>;
 }
 
-interface ReaddirpOptions {
-  root?: string;
-  fileFilter?: string | string[] | ((entry: EntryInfo) => boolean),
-  directoryFilter?: (entry: EntryInfo) => boolean,
-  type?: 'files' | 'directories' | 'files_directories' | 'all'
-  lstat?: boolean,
-  depth?: number
-  alwaysStat?: boolean
-}
+declare function readdir(
+  root: string,
+  options?: readdir.ReaddirpOptions
+): readdir.ReaddirpStream;
 
-declare class ReaddirpStream extends Readable implements AsyncIterable<EntryInfo> {
-  read(): EntryInfo;
-  [Symbol.asyncIterator](): AsyncIterableIterator<EntryInfo>;
-}
-
-declare const readdir: {
-  (root: string, options?: ReaddirpOptions): ReaddirpStream;
-  promise(root: string, options?: ReaddirpOptions): Promise<Array<EntryInfo>>;
-  ReaddirpStream: ReaddirpStream;
-  EntryInfo: EntryInfo;
-};
 export = readdir;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "filter"
   ],
   "scripts": {
-    "test": "nyc mocha"
+    "test": "nyc mocha && dtslint"
   },
   "dependencies": {
     "picomatch": "^2.0.4"
@@ -41,6 +41,7 @@
     "@types/node": "^12",
     "chai": "^4.2",
     "chai-subset": "^1.6",
+    "dtslint": "^0.9.8",
     "mocha": "~6.1.3",
     "nyc": "^14.1.1",
     "rimraf": "^2.6.3"


### PR DESCRIPTION
ensure EntryInfo, ReadDirpOptions, and ReadDirpStream are exported so downstream typings can leverage them.
Add dtslint to test process to ensure typings work as expected.

resolves https://github.com/gitsome/json-schema-validators-typscript-interfaces/issues/14#issuecomment-536014882