### PR TITLE
fix streams behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,7 +242,7 @@ class ReaddirpStream extends Readable {
   _emitPushIfUserWantsDir(entry) {
     if (DIR_TYPES.has(this._entryType)) {
       // TODO: Understand why this happens.
-      const fn = () => {this._push(entry)};
+      const fn = () => {this.push(entry)};
       if (this._isDirent) setImmediate(fn);
       else fn();
     }
@@ -250,12 +250,6 @@ class ReaddirpStream extends Readable {
 
   _emitPushIfUserWantsFile(entry) {
     if (FILE_TYPES.has(this._entryType)) {
-      this._push(entry);
-    }
-  }
-
-  _push(entry) {
-    if (!this.destroyed) {
       this.push(entry);
     }
   }


### PR DESCRIPTION
Fixes some minor streams related issues.

- Use `destroy(err)` to ensure `'error'` is only emitted once and in the next tick. Also ensures internal stream state is properly set and the `'close'` and '`error'` events are emitted in the correct order and tick.
- Use `destroyed` instead of `readable`.
- Use `autoDestroy` to ensure stream is destroyed properly and emits `'close'` once completed.
- Don't swallow `'error'` that occurs after `destroyed` but before `'close'`.
- Don't override `Readable.destroy`. Doing so can have unforeseen consequences. 

This ensures that it behaves like a "proper" stream and follows expectations.