### PR TITLE
Lint codebase

### DIFF
--- a/examples/grep.js
+++ b/examples/grep.js
@@ -1,20 +1,20 @@
-let {join} = require('path');
-let {createReadStream} = require('fs');
-let es = require('event-stream');
+const {createReadStream} = require('fs');
+const es = require('event-stream');
+const readdirp = require('..');
 
 const findLinesMatching = (searchTerm) => {
   return es.through(function (entry) {
     let lineno = 0;
-    let matchingLines = [];
-    let fileStream = this;
+    const matchingLines = [];
+    const fileStream = this;
 
-    fsCreateReadStream(entry.fullPath, {encoding: 'utf-8'})
+    createReadStream(entry.fullPath, {encoding: 'utf-8'})
       // handle file contents line by line
       .pipe(es.split('\n'))
       // filter, keep only the lines that matched the term
       .pipe(es.mapSync((line) => {
         lineno++;
-        return ~line.indexOf(searchTerm) ? lineno + ': ' + line : undefined;
+        return ~line.indexOf(searchTerm) ? `${lineno}: ${line}` : undefined;
       }))
       // aggregate matching lines and delegate control back to the file stream
       .pipe(es.through(
@@ -22,7 +22,7 @@ const findLinesMatching = (searchTerm) => {
         () => {
         // drop files that had no matches
         if (matchingLines.length) {
-          let result = { file: entry, lines: matchingLines };
+          const result = { file: entry, lines: matchingLines };
           fileStream.emit('data', result); // pass result on to file stream
         }
         this.emit('end');
@@ -35,8 +35,8 @@ const findLinesMatching = (searchTerm) => {
 // for each file (if none found, that file is ignored)
 readdirp(__dirname, {fileFilter: '*.js'})
   .pipe(findLinesMatching('arguments'))
-  .pipe(es.mapSync(function (res) {
+  .pipe(es.mapSync((res) => {
     // format the results and output
-    return '\n\n' + res.file.path + '\n\t' + res.lines.join('\n\t');
+    return `\n\n${res.file.path}\n\t${res.lines.join('\n\t')}`;
   }))
   .pipe(process.stdout);


### PR DESCRIPTION
* remove unused variables
* remove unneeded else clauses
* use `const` when possible
* use template liters
* use spread
* throw a `TypeError` instead of a generic error
* use `forEach` instead of `map` since we don't return anything
* remove trailing commas and add missing semicolons