### PR TITLE
package.json: Node.js >= 8.10.0 is required.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "Paul Miller (https://paulmillr.com)"
   ],
   "engines": {
-    "node": ">= 8"
+    "node": ">=8.10.0"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
This is due to picomatch using spread.