### PR TITLE
perf: emit entry early

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,11 +146,12 @@ class ReaddirpStream extends Readable {
 
     this.filesToRead += files.length;
 
-    const entries = await Promise.all(files.map(dirent => this._formatEntry(dirent, parent)));
+    const promises = files.map(dirent => this._formatEntry(dirent, parent));
 
-    if (this.destroyed) return;
-
-    for (const entry of entries) {
+    for (const promise of promises) {
+      const entry = await promise
+      // If the stream was destroyed, after readdir is completed
+      if (this.destroyed) return;
       this.filesToRead--;
       if (!entry) {
         continue;


### PR DESCRIPTION
No reason to wait for all entries. Emit as early as possible. If order doesn't matter this could be further improved.