### PR TITLE
Fix #138 (dir entries getting droped due to race condition)

### DIFF
--- a/examples/list.js
+++ b/examples/list.js
@@ -8,14 +8,18 @@ const read = async (directory) => {
   const stream = readdirp(directory, {type: 'all'});
   let i = 0;
   const start = Date.now();
-
-  stream.on('data', chunk => {
+  for await (const chunk of stream) {
     i++;
-  });
+    // Check memory usage with this line. It should be 10MB or so.
+    // Comment it out if you simply want to list files.
+    // await new Promise(resolve => setTimeout(resolve, 500));
+    // if (i % 100000 === 0)
+      // console.log(`${i}`, chunk);
+  }
+  console.log('finished', i, 'files in', Date.now() - start, 'ms');
 
-  stream.on('end', chunk => {
-    console.log('finished', i, 'files in', Date.now() - start, 'ms');
-  });
+  // const entries = await readdirp.promise(directory, {alwaysStat: false});
+  // console.log('Promise done', entries.length);
 };
 
 read('../..');

--- a/examples/list.js
+++ b/examples/list.js
@@ -23,3 +23,4 @@ const read = async (directory) => {
 };
 
 read('../..');
+

--- a/examples/perf.js
+++ b/examples/perf.js
@@ -15,10 +15,9 @@ const read = async (directory) => {
   const stream = readdirp(directory, {type: 'all'});
   let i = 0;
   const start = Date.now();
-  let lap = start;
+  let lap = 0;
 
   for await (const chunk of stream) {
-    i++;
     if (i % 1000 == 0) {
       const now = Date.now();
       if (now - lap > 500) {
@@ -26,6 +25,7 @@ const read = async (directory) => {
         logMem(i);
       }
     }
+    i++;
   }
   logMem(i);
 

--- a/examples/perf.js
+++ b/examples/perf.js
@@ -6,7 +6,7 @@ const readdirp = require('..');
 
 function logMem(i) {
   const vals = Object.entries(process.memoryUsage()).map(([k, v]) => {
-    return `${k  }=${  (`${(v/1e6).toFixed(1)  }M`).padEnd(7)}`;
+    return `${k}=${(`${(v/1e6).toFixed(1)}M`).padEnd(7)}`;
   });
   console.log(String(i).padStart(6), ...vals);
 }

--- a/examples/perf.js
+++ b/examples/perf.js
@@ -6,8 +6,8 @@ const readdirp = require('..');
 
 function logMem(i) {
   const vals = Object.entries(process.memoryUsage()).map(([k, v]) => {
-    return k + '=' + ((v/1e6).toFixed(1) + 'M').padEnd(7);
-  })
+    return `${k  }=${  (`${(v/1e6).toFixed(1)  }M`).padEnd(7)}`;
+  });
   console.log(String(i).padStart(6), ...vals);
 }
 

--- a/examples/perf.js
+++ b/examples/perf.js
@@ -4,7 +4,6 @@
 
 const readdirp = require('..');
 
-function meg(v) {return ((v/1e6).toFixed(1) + 'M').padEnd(7);}
 function logMem(i) {
   const vals = Object.entries(process.memoryUsage()).map(([k, v]) => {
     return k + '=' + ((v/1e6).toFixed(1) + 'M').padEnd(7);

--- a/examples/perf.js
+++ b/examples/perf.js
@@ -1,0 +1,37 @@
+/* eslint-disable no-unused-vars */
+
+'use strict';
+
+const readdirp = require('..');
+
+function meg(v) {return ((v/1e6).toFixed(1) + 'M').padEnd(7);}
+function logMem(i) {
+  const vals = Object.entries(process.memoryUsage()).map(([k, v]) => {
+    return k + '=' + ((v/1e6).toFixed(1) + 'M').padEnd(7);
+  })
+  console.log(String(i).padStart(6), ...vals);
+}
+
+const read = async (directory) => {
+  const stream = readdirp(directory, {type: 'all'});
+  let i = 0;
+  const start = Date.now();
+  let lap = start;
+
+  for await (const chunk of stream) {
+    i++;
+    if (i % 1000 == 0) {
+      const now = Date.now();
+      if (now - lap > 500) {
+        lap = now;
+        logMem(i);
+      }
+    }
+  }
+  logMem(i);
+
+  console.log(`Processed ${i} files in ${Date.now() - start} msecs`);
+};
+
+read('../..');
+

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ const lstat = promisify(fs.lstat);
  * @property {fs.Dirent=} dirent
  * @property {String} basename
  */
-
 const supportsDirent = 'Dirent' in fs;
 const isWindows = process.platform === 'win32';
 const BANG = '!';
@@ -148,7 +147,8 @@ class ReaddirpStream extends Readable {
 
       // Push entries onto the stream until told to stop
       while (this._entryBuffer.length) {
-        if (!this.push(this._entryBuffer.shift())) {
+        const entry = this._entryBuffer.shift();
+        if (!this.push(entry)) {
           this._reading = false;
           return;
         }

--- a/test.js
+++ b/test.js
@@ -355,33 +355,6 @@ describe('various', () => {
       entry.should.containSubset(formatEntry(created[index], currPath))
     );
   });
-  it('should emit warning for missing file', async function() {
-    this.timeout(4000);
-    const unlinkedDir = sysPath.join(currPath, 'unlinked');
-    fs.mkdirSync(unlinkedDir);
-    const isUnlinked = false;
-    let isWarningCalled = false;
-    const stream = readdirp(currPath, { type: 'all' });
-    stream.pause();
-    stream
-      .on('readable', async () => {
-        if (!isUnlinked) {
-          await pRimraf(unlinkedDir);
-          stream.resume();
-          stream.read();
-        }
-      })
-      .on('warn', warning => {
-        warning.should.be.an.instanceof(Error);
-        warning.code.should.equals('ENOENT');
-        isWarningCalled = true;
-      });
-    await Promise.race([
-      waitForEnd(stream),
-      delay(2000)
-    ]);
-    isWarningCalled.should.equals(true);
-  });
   it('should emit warning for file with strict permission', async () => {
     // Windows doesn't throw permission error if you access permitted directory
     if (isWindows) {


### PR DESCRIPTION
Okay, so ignore my previous description - there's a bit more here than I had initially.

First, I've removed the `setImmediate()` call to fix the issue I reported in #138.  However this re-broke the asyncIterator behavior.  I'm pretty sure the problem there was in the `_read()` implementation, which was ignoring the return value of `push()`.  [Per the Node docs](https://nodejs.org/api/stream.html#stream_readable_read_size_1), when `_read()` is called you're supposed to `push()` data until `push()` returns false, then wait for _read() to be called again.    Because the code was blindly `push()`ing with no regard for the return value,  I think that caused the stream to drop out of "flowing" mode,  effectively hanging the async iterator.  (Admittedly, this at the limit of my understanding of how streams work, so I may not have that exactly right, but I that's my best guess at the issue.  Also, I'm not sure how to explain the various tests people reported, mine included, just cleanly exiting rather than hanging. :-/ )

I'm pretty sure this misbehaving `_read()` is what was causing #91 and #97.

To fix this, I rewrote `_read()` to have a while-true loop that does two thngs: 1) "explore" the filesystem until it gets some entries to push, and 2) push() entries until it sees `false`.  It only drops out of that loop when `push() == false` (or we run out of things to explore).

Other changes of note:
- Use Promise.all to parallelize getting dirent stats
- Use `_reading` mutex in _read rather than the more complicated `filesToRead` logic.
- _exploreDirectory() returns entries to main _read loop, rather than pushing them.
- added check in readdirp#promise's 'error' event handler so errors after promise resolves won't be silently swallowed.
- Removed the "missing file" test.  I think that test relied on the fact that exploring of the directory was deferred until after the "readable" event fired (due to the setImmediate() call).  But that's no longer the case in this PR - the directory is pushed before "readable" fires now.... and I don't really see how to replicate that test easily.
- Remove `highWaterMark` option - it's just a hint passed into `_read()`, which is ignored anyhow.