### PR TITLE
highwatermark option

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,11 @@ class ReaddirpStream extends Readable {
   }
 
   constructor(options = {}) {
-    super({ objectMode: true, autoDestroy: true, highWaterMark: 1 });
+    super({
+      objectMode: true,
+      autoDestroy: true,
+      highWaterMark: options.highWaterMark
+    });
     const opts = { ...ReaddirpStream.defaultOptions, ...options };
     const { root } = opts;
 

--- a/test.js
+++ b/test.js
@@ -361,7 +361,7 @@ describe('various', () => {
     fs.mkdirSync(unlinkedDir);
     const isUnlinked = false;
     let isWarningCalled = false;
-    const stream = readdirp(currPath, { type: 'all' });
+    const stream = readdirp(currPath, { type: 'all', highWaterMark: 1 });
     stream.pause();
     stream
       .on('readable', async () => {


### PR DESCRIPTION
highwatermark: 1 will negatively impact performance, but a larger value breaks a test scenario which depends on the number of elements buffered.

This fixes both.