### PR TITLE
Update check for fs.stat/fs.lstat bigint support.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const ALL_TYPES = [FILE_TYPE, DIR_TYPE, FILE_DIR_TYPE, EVERYTHING_TYPE];
 
 const isNormalFlowError = error => NORMAL_FLOW_ERRORS.has(error.code);
 const [maj, min] = process.versions.node.split('.').slice(0, 2).map(n => Number.parseInt(n));
-const wantBigintFsStats = process.platform === 'win32' && (maj > 10 || maj === 10 && min >= 5));
+const wantBigintFsStats = process.platform === 'win32' && (maj > 10 || (maj === 10 && min >= 5));
 
 const normalizeFilter = filter => {
   if (filter === undefined) return;

--- a/index.js
+++ b/index.js
@@ -30,10 +30,8 @@ const EVERYTHING_TYPE = 'all';
 const ALL_TYPES = [FILE_TYPE, DIR_TYPE, FILE_DIR_TYPE, EVERYTHING_TYPE];
 
 const isNormalFlowError = error => NORMAL_FLOW_ERRORS.has(error.code);
-const fsStatSupportsBigInt = () => {
-    const versionParts = process.versions.node.split('.').slice(0,2).map(Number);
-    return versionParts[0] > 10 || (versionParts[0] == 10 && versionParts[1] >= 5);
-};
+const [maj, min] = process.versions.node.split('.').slice(0, 2).map(n => Number.parseInt(n));
+const wantBigintFsStats = process.platform === 'win32' && (maj > 10 || maj === 10 && min >= 5));
 
 const normalizeFilter = filter => {
   if (filter === undefined) return;
@@ -96,7 +94,7 @@ class ReaddirpStream extends Readable {
 
     const statMethod = opts.lstat ? lstat : stat;
     // Use bigint stats if it's windows and stat() supports options (node 10+).
-    if (process.platform === 'win32' && fsStatSupportsBigInt()) {
+    if (wantBigintFsStats) {
       this._stat = path => statMethod(path, { bigint: true });
     } else {
       this._stat = statMethod;

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const EVERYTHING_TYPE = 'all';
 const ALL_TYPES = [FILE_TYPE, DIR_TYPE, FILE_DIR_TYPE, EVERYTHING_TYPE];
 
 const isNormalFlowError = error => NORMAL_FLOW_ERRORS.has(error.code);
-const [maj, min] = process.versions.node.split('.').slice(0, 2).map(n => Number.parseInt(n));
+const [maj, min] = process.versions.node.split('.').slice(0, 2).map(n => Number.parseInt(n, 10));
 const wantBigintFsStats = process.platform === 'win32' && (maj > 10 || (maj === 10 && min >= 5));
 
 const normalizeFilter = filter => {

--- a/index.js
+++ b/index.js
@@ -30,6 +30,10 @@ const EVERYTHING_TYPE = 'all';
 const ALL_TYPES = [FILE_TYPE, DIR_TYPE, FILE_DIR_TYPE, EVERYTHING_TYPE];
 
 const isNormalFlowError = error => NORMAL_FLOW_ERRORS.has(error.code);
+const fsStatSupportsBigInt = () => {
+    const versionParts = process.versions.node.split('.').slice(0,2).map(Number);
+    return versionParts[0] > 10 || (versionParts[0] == 10 && versionParts[1] >= 5);
+};
 
 const normalizeFilter = filter => {
   if (filter === undefined) return;
@@ -92,7 +96,7 @@ class ReaddirpStream extends Readable {
 
     const statMethod = opts.lstat ? lstat : stat;
     // Use bigint stats if it's windows and stat() supports options (node 10+).
-    if (process.platform === 'win32' && stat.length === 3) {
+    if (process.platform === 'win32' && fsStatSupportsBigInt()) {
       this._stat = path => statMethod(path, { bigint: true });
     } else {
       this._stat = statMethod;


### PR DESCRIPTION
Fix:
https://github.com/paulmillr/readdirp/issues/170

I'm just checking that the node version exceeds 10.5 [per the documentation](https://nodejs.org/api/fs.html#fs_fs_stat_path_options_callback): 

 I haven't actually tested against the full list of release coming out of `process.versions`: [Node releases](https://nodejs.org/en/download/releases/). Can write a test for that if necessary.