### PR TITLE
improve typing for `readdirpPromise`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -274,7 +274,7 @@ export const readdirp = (root: Path, options: Partial<ReaddirpOptions> = {}) => 
 };
 
 export const readdirpPromise = (root: Path, options: Partial<ReaddirpOptions> = {}) => {
-  return new Promise((resolve, reject) => {
+  return new Promise<Path[]>((resolve, reject) => {
     const files: Path[] = [];
     readdirp(root, options)
       .on('data', (entry) => files.push(entry))


### PR DESCRIPTION
Currently, the type of return value of `readdirpPromise` is `Promise<unknown>`. I fixed the type to `Promise<string[]>`.