### PR TITLE
Fix broken repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/paulmillr/readdirp",
   "repository": {
     "type": "git",
-    "url": "git://github.com/paulmillr/readdirp.git"
+    "url": "https://github.com/paulmillr/readdirp.git"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
GitHub hasn't supported the git protocol [since 2022](https://github.blog/security/application-security/improving-git-protocol-security-github/#no-more-unauthenticated-git), so this URL is broken.

(This is a common error affecting many popular npm packages; I'm opening PRs on several projects to fix it. I encourage anyone reading this to check any packages they maintain and implement the same fix if appropriate!)